### PR TITLE
Trigger the Change Handler on Selection

### DIFF
--- a/lib/jquery.timezone-picker.js
+++ b/lib/jquery.timezone-picker.js
@@ -53,11 +53,19 @@ methods.init = function(initOpts) {
       // Update the target select list.
       if (opts.target) {
         var timezoneName = $(areaElement).attr('data-timezone');
+        if (timezoneName == $(opts.target).val()) {
+          return
+        }
         if (timezoneName) $(opts.target).val(timezoneName);
+        $(opts.target).triggerHandler('change');
       }
       if (opts.countryTarget) {
         var countryName = $(areaElement).attr('data-country');
+        if (countryName == $(opts.countryTarget).val()) {
+          return
+        }
         if (countryName) $(opts.countryTarget).val(countryName);
+        $(opts.countryTarget).triggerHandler('change');
       }
 
       return false;
@@ -281,7 +289,7 @@ $.fn.timezonePicker = function(method) {
   }
   else {
     $.error('Method ' +  method + ' does not exist on jQuery.timezonePicker');
-  } 
+  }
 };
 
 $.fn.timezonePicker.defaults = {


### PR DESCRIPTION
I was surprised when the change event wasn't fired on the `target` (and `countryName`) inputs. My solution is a bit of a hack (it allows for one spurious call to `click` from `updateTarget`) in that it only guards against redundant triggers, but I wanted a minimally invasive change. This was important for my integration with an AngularJS project.
