### PR TITLE
Make changeHandler not getting overwritten if set

### DIFF
--- a/lib/jquery.timezone-picker.js
+++ b/lib/jquery.timezone-picker.js
@@ -20,7 +20,7 @@ methods.init = function(initOpts) {
   opts = $.extend({}, $.fn.timezonePicker.defaults, initOpts);
   selectedTimezone = opts.timezone;
 
-  changeHandler = opts.changeHandler;
+  changeHandler = changeHandler || opts.changeHandler;
 
   return $origCall.each(function(index, item) {
     imgElement = item;


### PR DESCRIPTION
If changeHandler is set in the code at line 14, its value gets overwritten by opt.changeHandler a couple of lines further down. This patch checks if changeHandler is already defined, and in that case uses that value.
